### PR TITLE
add request logging middleware with correlation of IDs

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -14,6 +14,7 @@ from core.features import FeatureManager
 from core.logging import configure_logging
 from infrastructure.observability.telemetry import initialize_telemetry
 from presentation.api.middleware.auth import AuthMiddleware
+from presentation.api.middleware.logging import RequestLoggingMiddleware
 
 
 @asynccontextmanager
@@ -110,6 +111,8 @@ def create_app() -> FastAPI:
             r"https://.*\.github\.dev" if settings.security.demo_mode_enabled else None
         ),
     )
+
+    app.add_middleware(RequestLoggingMiddleware)
 
     # Configure Authentication Middleware
     app.add_middleware(

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -112,8 +112,6 @@ def create_app() -> FastAPI:
         ),
     )
 
-    app.add_middleware(RequestLoggingMiddleware)
-
     # Configure Authentication Middleware
     app.add_middleware(
         AuthMiddleware,
@@ -134,6 +132,8 @@ def create_app() -> FastAPI:
         enable_api_key=False,
         security_settings=settings.security,
     )
+
+    app.add_middleware(RequestLoggingMiddleware)
 
     # Include API routers
     from presentation.api.routes import (

--- a/backend/src/presentation/api/middleware/__init__.py
+++ b/backend/src/presentation/api/middleware/__init__.py
@@ -1,0 +1,15 @@
+"""API middleware exports."""
+
+from presentation.api.middleware.auth import AuthMiddleware
+from presentation.api.middleware.logging import (
+    CORRELATION_ID_HEADER,
+    RequestLoggingMiddleware,
+    get_correlation_id,
+)
+
+__all__ = [
+    "AuthMiddleware",
+    "CORRELATION_ID_HEADER",
+    "RequestLoggingMiddleware",
+    "get_correlation_id",
+]

--- a/backend/src/presentation/api/middleware/__init__.py
+++ b/backend/src/presentation/api/middleware/__init__.py
@@ -1,7 +1,7 @@
 """API middleware exports."""
 
-from presentation.api.middleware.auth import AuthMiddleware
-from presentation.api.middleware.logging import (
+from .auth import AuthMiddleware
+from .logging import (
     CORRELATION_ID_HEADER,
     RequestLoggingMiddleware,
     get_correlation_id,

--- a/backend/src/presentation/api/middleware/logging.py
+++ b/backend/src/presentation/api/middleware/logging.py
@@ -1,0 +1,103 @@
+"""Request logging middleware for FastAPI."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from datetime import UTC, datetime
+from time import perf_counter
+from uuid import uuid4
+
+from loguru import logger
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+CORRELATION_ID_HEADER = "X-Correlation-ID"
+_correlation_id_context: ContextVar[str | None] = ContextVar(
+    "request_correlation_id",
+    default=None,
+)
+
+
+def get_correlation_id() -> str | None:
+    """Return the correlation ID for the current request context."""
+
+    return _correlation_id_context.get()
+
+
+class RequestLoggingMiddleware:
+    """Log inbound API requests with correlation IDs and latency."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Initialize middleware with the downstream ASGI app."""
+
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Log request lifecycle details and attach correlation metadata."""
+
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        correlation_id = self._get_correlation_id(scope)
+        context_token = self._set_correlation_context(correlation_id)
+        scope.setdefault("state", {})["correlation_id"] = correlation_id
+
+        request_logger = logger.bind(
+            correlation_id=correlation_id,
+            method=scope["method"],
+            path=scope["path"],
+            timestamp=datetime.now(UTC).isoformat(),
+        )
+        start_time = perf_counter()
+        response_status: int | None = None
+
+        request_logger.info("HTTP request started")
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal response_status
+
+            if message["type"] == "http.response.start":
+                response_status = message["status"]
+                headers = MutableHeaders(scope=message)
+                headers[CORRELATION_ID_HEADER] = correlation_id
+
+            if message["type"] == "http.response.body" and not message.get("more_body", False):
+                latency_ms = self._latency_ms(start_time)
+                request_logger.bind(status=response_status, latency_ms=latency_ms).info(
+                    "HTTP request completed"
+                )
+
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        except Exception:
+            latency_ms = self._latency_ms(start_time)
+            request_logger.bind(latency_ms=latency_ms).opt(exception=True).error(
+                "HTTP request failed"
+            )
+            raise
+        finally:
+            self._reset_correlation_context(context_token)
+
+    def _get_correlation_id(self, scope: Scope) -> str:
+        """Return inbound correlation ID header or generate a new one."""
+
+        headers = Headers(scope=scope)
+        return headers.get(CORRELATION_ID_HEADER) or str(uuid4())
+
+    def _set_correlation_context(self, correlation_id: str) -> Token[str | None]:
+        """Store the correlation ID in context for downstream access."""
+
+        return _correlation_id_context.set(correlation_id)
+
+    def _reset_correlation_context(self, token: Token[str | None]) -> None:
+        """Reset correlation context after request completion."""
+
+        _correlation_id_context.reset(token)
+
+    def _latency_ms(self, start_time: float) -> float:
+        """Return elapsed time in milliseconds."""
+
+        return round((perf_counter() - start_time) * 1000, 3)

--- a/backend/src/presentation/api/middleware/logging.py
+++ b/backend/src/presentation/api/middleware/logging.py
@@ -8,6 +8,7 @@ from time import perf_counter
 from uuid import uuid4
 
 from loguru import logger
+from starlette.responses import PlainTextResponse
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -77,7 +78,11 @@ class RequestLoggingMiddleware:
             request_logger.bind(latency_ms=latency_ms).opt(exception=True).error(
                 "HTTP request failed"
             )
-            raise
+            if response_status is not None:
+                raise
+
+            await self._send_internal_server_error(scope, receive, send, correlation_id)
+            request_logger.bind(status=500, latency_ms=latency_ms).info("HTTP request completed")
         finally:
             self._reset_correlation_context(context_token)
 
@@ -101,3 +106,19 @@ class RequestLoggingMiddleware:
         """Return elapsed time in milliseconds."""
 
         return round((perf_counter() - start_time) * 1000, 3)
+
+    async def _send_internal_server_error(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        correlation_id: str,
+    ) -> None:
+        """Send a fallback 500 response that preserves correlation metadata."""
+
+        response = PlainTextResponse(
+            "Internal Server Error",
+            status_code=500,
+            headers={CORRELATION_ID_HEADER: correlation_id},
+        )
+        await response(scope, receive, send)

--- a/backend/tests/unit/test_logging_middleware.py
+++ b/backend/tests/unit/test_logging_middleware.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, Request
 from starlette.testclient import TestClient
 
 from main import create_app
+from presentation.api.middleware.auth import AuthMiddleware
 from presentation.api.middleware.logging import CORRELATION_ID_HEADER, RequestLoggingMiddleware
 
 
@@ -123,3 +124,17 @@ class TestMainApplicationLoggingMiddleware:
         middleware_classes = [middleware.cls for middleware in app.user_middleware]
 
         assert RequestLoggingMiddleware in middleware_classes
+        assert middleware_classes.index(RequestLoggingMiddleware) < middleware_classes.index(
+            AuthMiddleware
+        )
+
+    def test_create_app_unauthorized_response_includes_correlation_id(self) -> None:
+        """Test logging middleware wraps unauthorized responses from auth middleware."""
+        app = create_app()
+        client = TestClient(app)
+
+        response = client.get("/api/v1/auth/session")
+
+        assert response.status_code == 401
+        assert CORRELATION_ID_HEADER in response.headers
+        assert response.headers[CORRELATION_ID_HEADER]

--- a/backend/tests/unit/test_logging_middleware.py
+++ b/backend/tests/unit/test_logging_middleware.py
@@ -1,0 +1,117 @@
+"""Tests for request logging middleware."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI, Request
+from starlette.testclient import TestClient
+
+from main import create_app
+from presentation.api.middleware.logging import CORRELATION_ID_HEADER, RequestLoggingMiddleware
+
+
+class TestRequestLoggingMiddleware:
+    """Tests for request logging behavior."""
+
+    def test_generates_correlation_id_and_logs_request_lifecycle(self) -> None:
+        """Test middleware generates correlation IDs and logs start/end events."""
+        app = FastAPI()
+
+        @app.get("/ping")
+        async def ping(request: Request) -> dict[str, str]:
+            return {"correlation_id": request.state.correlation_id}
+
+        with patch("presentation.api.middleware.logging.logger") as mock_logger:
+            bound_logger = MagicMock()
+            chained_logger = MagicMock()
+            mock_logger.bind.return_value = bound_logger
+            bound_logger.bind.return_value = chained_logger
+
+            app.add_middleware(RequestLoggingMiddleware)
+            client = TestClient(app)
+
+            response = client.get("/ping")
+
+        assert response.status_code == 200
+        correlation_id = response.headers[CORRELATION_ID_HEADER]
+        assert correlation_id
+        assert response.json()["correlation_id"] == correlation_id
+
+        mock_logger.bind.assert_called_once()
+        bind_kwargs = mock_logger.bind.call_args.kwargs
+        assert bind_kwargs["correlation_id"] == correlation_id
+        assert bind_kwargs["method"] == "GET"
+        assert bind_kwargs["path"] == "/ping"
+        bound_logger.info.assert_called_once_with("HTTP request started")
+
+        response_log_call = bound_logger.bind.call_args.kwargs
+        assert response_log_call["status"] == 200
+        assert response_log_call["latency_ms"] >= 0
+        chained_logger.info.assert_called_once_with("HTTP request completed")
+
+    def test_preserves_incoming_correlation_id_and_exposes_context(self) -> None:
+        """Test middleware reuses incoming correlation ID and exposes it to handlers."""
+        app = FastAPI()
+
+        @app.get("/context")
+        async def context(request: Request) -> dict[str, str | None]:
+            from presentation.api.middleware.logging import get_correlation_id
+
+            return {
+                "state_correlation_id": request.state.correlation_id,
+                "context_correlation_id": get_correlation_id(),
+            }
+
+        app.add_middleware(RequestLoggingMiddleware)
+        client = TestClient(app)
+
+        response = client.get("/context", headers={CORRELATION_ID_HEADER: "abc-123"})
+
+        assert response.status_code == 200
+        assert response.headers[CORRELATION_ID_HEADER] == "abc-123"
+        assert response.json() == {
+            "state_correlation_id": "abc-123",
+            "context_correlation_id": "abc-123",
+        }
+
+    def test_logs_errors_with_request_context(self) -> None:
+        """Test middleware logs unhandled exceptions with correlation context."""
+        app = FastAPI()
+
+        @app.get("/boom")
+        async def boom() -> None:
+            raise RuntimeError("boom")
+
+        with patch("presentation.api.middleware.logging.logger") as mock_logger:
+            bound_logger = MagicMock()
+            error_logger = MagicMock()
+            opt_logger = MagicMock()
+            mock_logger.bind.return_value = bound_logger
+            bound_logger.bind.return_value = error_logger
+            error_logger.opt.return_value = opt_logger
+
+            app.add_middleware(RequestLoggingMiddleware)
+            client = TestClient(app, raise_server_exceptions=False)
+
+            response = client.get("/boom")
+
+        assert response.status_code == 500
+        bound_logger.info.assert_called_once_with("HTTP request started")
+
+        error_bind_kwargs = bound_logger.bind.call_args.kwargs
+        assert error_bind_kwargs["latency_ms"] >= 0
+        error_logger.opt.assert_called_once_with(exception=True)
+        opt_logger.error.assert_called_once_with("HTTP request failed")
+
+
+class TestMainApplicationLoggingMiddleware:
+    """Tests for logging middleware registration."""
+
+    def test_create_app_registers_logging_middleware(self) -> None:
+        """Test main app includes request logging middleware."""
+        app = create_app()
+
+        middleware_classes = [middleware.cls for middleware in app.user_middleware]
+
+        assert RequestLoggingMiddleware in middleware_classes

--- a/backend/tests/unit/test_logging_middleware.py
+++ b/backend/tests/unit/test_logging_middleware.py
@@ -97,10 +97,18 @@ class TestRequestLoggingMiddleware:
             response = client.get("/boom")
 
         assert response.status_code == 500
+        correlation_id = response.headers[CORRELATION_ID_HEADER]
+        assert correlation_id
         bound_logger.info.assert_called_once_with("HTTP request started")
+
+        bind_kwargs = mock_logger.bind.call_args.kwargs
+        assert bind_kwargs["correlation_id"] == correlation_id
+        assert bind_kwargs["method"] == "GET"
+        assert bind_kwargs["path"] == "/boom"
 
         error_bind_kwargs = bound_logger.bind.call_args.kwargs
         assert error_bind_kwargs["latency_ms"] >= 0
+        assert error_bind_kwargs["status"] == 500
         error_logger.opt.assert_called_once_with(exception=True)
         opt_logger.error.assert_called_once_with("HTTP request failed")
 


### PR DESCRIPTION
Author: @goyaljiiiiiii

This PR adds request logging middleware to improve API observability and make production debugging easier.

- added a new middleware at `backend/src/presentation/api/middleware/logging.py`
- registered the middleware in `backend/src/main.py`
- exported the middleware from `backend/src/presentation/api/middleware/__init__.py`
- added focused unit tests in `backend/tests/unit/test_logging_middleware.py`

## Files Changed

- `backend/src/presentation/api/middleware/logging.py`
- `backend/src/main.py`
- `backend/src/presentation/api/middleware/__init__.py`
- `backend/tests/unit/test_logging_middleware.py`

Reference Issue: #15 